### PR TITLE
Adapt regex in test to match new timestamp format

### DIFF
--- a/t/06-datetime-formatter.t
+++ b/t/06-datetime-formatter.t
@@ -18,7 +18,7 @@ class Handle is IO::Handle {
 
     my $msg = 'test message';
     $log.info($msg);
-    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z]'?/, 'standard timestamp');
+    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z'?/, 'standard timestamp');
 }
 
 {

--- a/t/06-datetime-formatter.t
+++ b/t/06-datetime-formatter.t
@@ -18,7 +18,7 @@ class Handle is IO::Handle {
 
     my $msg = 'test message';
     $log.info($msg);
-    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+/, 'standard timestamp');
+    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z]'?/, 'standard timestamp');
 }
 
 {

--- a/t/06-datetime-formatter.t
+++ b/t/06-datetime-formatter.t
@@ -18,7 +18,7 @@ class Handle is IO::Handle {
 
     my $msg = 'test message';
     $log.info($msg);
-    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z'?/, 'standard timestamp');
+    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z'? ']'/, 'standard timestamp');
 }
 
 {

--- a/t/06-datetime-formatter.t
+++ b/t/06-datetime-formatter.t
@@ -18,7 +18,7 @@ class Handle is IO::Handle {
 
     my $msg = 'test message';
     $log.info($msg);
-    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+ 'Z]'/, 'standard timestamp');
+    like($log.output.get, /^ '[' \d+ '-' \d+ '-' \d+ 'T' \d+ ':' \d+ ':' \d+ '.' \d+/, 'standard timestamp');
 }
 
 {


### PR DESCRIPTION
Hi, I noticed a test fail and took a look. Looks like the standard format has changed. At least the test fails because there is no longer an Z at the end of the timestamp.

I removed it and hope that fixes this kind of issue for good.